### PR TITLE
fix: make server-side compatible

### DIFF
--- a/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
+++ b/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
@@ -1,21 +1,21 @@
+import { isPlatformServer } from '@angular/common';
 import {
   AfterViewInit,
   Directive,
   ElementRef,
   HostListener,
+  Inject,
   Input,
   OnInit,
   Optional,
+  PLATFORM_ID,
   Renderer2,
   Self,
 } from '@angular/core';
 import { ControlValueAccessor, NgControl, Validator } from '@angular/forms';
 import Inputmask from 'inputmask';
 
-@Directive({
-  selector: '[inputMask]',
-  providers: [],
-})
+@Directive({ selector: '[inputMask]' })
 export class InputMaskDirective<T = any>
   implements OnInit, AfterViewInit, ControlValueAccessor, Validator {
   /**
@@ -27,6 +27,7 @@ export class InputMaskDirective<T = any>
   inputMaskPlugin: Inputmask.Instance | undefined;
 
   constructor(
+    @Inject(PLATFORM_ID) private platformId: string,
     private elementRef: ElementRef,
     private renderer: Renderer2,
     @Optional() @Self() public ngControl: NgControl
@@ -45,6 +46,10 @@ export class InputMaskDirective<T = any>
   }
 
   ngAfterViewInit() {
+    if (isPlatformServer(this.platformId)) {
+      return;
+    }
+
     if (Object.keys(this.inputMask).length) {
       this.inputMaskPlugin = new Inputmask(this.inputMaskOptions).mask(
         this.elementRef.nativeElement


### PR DESCRIPTION
There's no sense to initialize the inputmask class on the Node.js side since validations are performed on the client-side. This is what happens when trying to run a simple server:

![image](https://user-images.githubusercontent.com/7337691/124510949-98713900-dddd-11eb-867c-1f0e6a862795.png)
