### PR TITLE
Feat/blur: Enabling updateOn 'blur' functionality

### DIFF
--- a/projects/ngneat/input-mask/src/lib/input-mask.directive.spec.ts
+++ b/projects/ngneat/input-mask/src/lib/input-mask.directive.spec.ts
@@ -9,6 +9,11 @@ import { InputMaskModule } from './input-mask.module';
     <input class="date" [inputMask]="dateMask" [formControl]="dateFC" />
     <input class="ip" [inputMask]="ipAddressMask" [formControl]="ipFC" />
     <input class="initDate" [inputMask]="dateMask" [formControl]="initDateFC" />
+    <input
+      class="dateOnBlur"
+      [inputMask]="dateMask"
+      [formControl]="dateBlurFC"
+    />
   `,
 })
 class TestComponent {
@@ -24,6 +29,7 @@ class TestComponent {
     },
   });
   dateFC = new FormControl('');
+  dateBlurFC = new FormControl('', { updateOn: 'blur' });
   initDateFC = new FormControl('28/02/1992');
 
   ipAddressMask = createMask({ alias: 'ip' });
@@ -69,5 +75,15 @@ describe('InputMaskDirective', () => {
   it('should render with initial value', () => {
     const input = spectator.query('.initDate') as HTMLInputElement;
     expect(input.value).toEqual('28/02/1992');
+  });
+
+  it('should update the UI value as per mask with updateOn: \'blur\'', () => {
+    const input = spectator.query('.dateOnBlur') as HTMLInputElement;
+    spectator.typeInElement('28021992', '.dateOnBlur');
+    expect(input.value).toEqual('28/02/1992');
+    expect(spectator.component.dateBlurFC.value).toBeFalsy();
+    spectator.blur('.dateOnBlur');
+    expect(input.value).toEqual('28/02/1992');
+    expect(spectator.component.dateBlurFC.value).toEqual(new Date(1992, 1, 28));
   });
 });

--- a/projects/ngneat/input-mask/src/lib/input-mask.directive.spec.ts
+++ b/projects/ngneat/input-mask/src/lib/input-mask.directive.spec.ts
@@ -82,8 +82,12 @@ describe('InputMaskDirective', () => {
     spectator.typeInElement('28021992', '.dateOnBlur');
     expect(input.value).toEqual('28/02/1992');
     expect(spectator.component.dateBlurFC.value).toBeFalsy();
+    expect(spectator.component.dateBlurFC.dirty).toBeFalse();
+    expect(spectator.component.dateBlurFC.touched).toBeFalse();
     spectator.blur('.dateOnBlur');
     expect(input.value).toEqual('28/02/1992');
     expect(spectator.component.dateBlurFC.value).toEqual(new Date(1992, 1, 28));
+    expect(spectator.component.dateBlurFC.dirty).toBeTrue();
+    expect(spectator.component.dateBlurFC.touched).toBeTrue();
   });
 });

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -25,7 +25,8 @@ Valid: {{ ipAddress.valid }} | Value: {{ ipAddress.value }} | Errors:
 {{ ipAddress.errors | json }}
 <p>--------------</p>
 <input [formControl]="dateFC" [inputMask]="dateInputMask" placeholder="Date" />
-Valid: {{ dateFC.valid }} | Value: {{ dateFC.value }} | Errors:
+Valid: {{ dateFC.valid }} | Dirty: {{ dateFC.dirty }}| Value:
+{{ dateFC.value }} | Errors:
 {{ dateFC.errors | json }}
 <p>-------------- update Value on blur</p>
 <input
@@ -33,5 +34,6 @@ Valid: {{ dateFC.valid }} | Value: {{ dateFC.value }} | Errors:
   [formControl]="dateBlurFC"
   [inputMask]="dateInputMask"
 />
-Valid: {{ dateBlurFC.valid }} | Value: {{ dateBlurFC.value }} | Errors:
+Valid: {{ dateBlurFC.valid }} | Dirty: {{ dateBlurFC.dirty }} | Value:
+{{ dateBlurFC.value }} | Errors:
 {{ dateBlurFC.errors | json }}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -27,3 +27,11 @@ Valid: {{ ipAddress.valid }} | Value: {{ ipAddress.value }} | Errors:
 <input [formControl]="dateFC" [inputMask]="dateInputMask" placeholder="Date" />
 Valid: {{ dateFC.valid }} | Value: {{ dateFC.value }} | Errors:
 {{ dateFC.errors | json }}
+<p>-------------- update Value on blur</p>
+<input
+  placeholder="Date"
+  [formControl]="dateBlurFC"
+  [inputMask]="dateInputMask"
+/>
+Valid: {{ dateBlurFC.valid }} | Value: {{ dateBlurFC.value }} | Errors:
+{{ dateBlurFC.errors | json }}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -34,4 +34,5 @@ export class AppComponent {
   ipAddressMask = createMask({ alias: 'ip' });
   ipAddress = new FormControl('');
   dateFC = new FormControl('');
+  dateBlurFC = new FormControl('', { updateOn: 'blur' });
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,7 +10,7 @@ import { createMask } from '@ngneat/input-mask';
 export class AppComponent {
   title: Date = new Date();
 
-  dateInputMask = createMask<Date>({
+  dateInputMask = createMask<Date | null>({
     alias: 'datetime',
     inputFormat: 'dd/mm/yyyy',
     parser: (value: string) => {
@@ -18,6 +18,10 @@ export class AppComponent {
       const year = +values[2];
       const month = +values[1] - 1;
       const date = +values[0];
+      if (isNaN(date) && isNaN(month) && isNaN(year)) {
+        // + empty string returns 0
+        return null;
+      }
       return new Date(year, month, date);
     },
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #7 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
This makes the `onBlur` behavior work, but I'm not 100% satisfied with the solution. My main issue is the necessity to store the initial value of the formControl in tne `onInit` hook in order to determine if the form Control should be dirty or not after bluring. If the value is not checked against the initial value in the onChange hook, just focussing in and out of the form control without manipulating marks it as dirty, which is not correct. Any ideas?