### PR TITLE
Fix/writevalue: Add null check to writeValue method

### DIFF
--- a/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
+++ b/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
@@ -11,7 +11,7 @@ import {
   Optional,
   PLATFORM_ID,
   Renderer2,
-  Self,
+  Self
 } from '@angular/core';
 import { ControlValueAccessor, NgControl, Validator } from '@angular/forms';
 import Inputmask from 'inputmask';
@@ -39,9 +39,9 @@ export class InputMaskDirective<T = any>
   }
 
   @HostListener('input', ['$event.target.value'])
-  onInput = (_: any) => {};
+  onInput = (_: any) => {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.ngControl?.control?.setValidators([this.validate.bind(this)]);
     this.ngControl?.control?.updateValueAndValidity();
   }
@@ -50,7 +50,7 @@ export class InputMaskDirective<T = any>
     this.inputMaskPlugin?.remove();
   }
 
-  ngAfterViewInit() {
+  ngAfterViewInit(): void {
     if (isPlatformServer(this.platformId)) {
       return;
     }
@@ -71,7 +71,9 @@ export class InputMaskDirective<T = any>
   }
 
   writeValue(value: string): void {
-    this.renderer.setProperty(this.elementRef.nativeElement, 'value', value);
+    if (value) {
+      this.renderer.setProperty(this.elementRef.nativeElement, 'value', value);
+    }
   }
 
   registerOnChange(fn: (_: T | null) => void): void {

--- a/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
+++ b/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
@@ -11,7 +11,7 @@ import {
   Optional,
   PLATFORM_ID,
   Renderer2,
-  Self
+  Self,
 } from '@angular/core';
 import { ControlValueAccessor, NgControl, Validator } from '@angular/forms';
 import Inputmask from 'inputmask';
@@ -39,7 +39,7 @@ export class InputMaskDirective<T = any>
   }
 
   @HostListener('input', ['$event.target.value'])
-  onInput = (_: any) => {}
+  onInput = (_: any) => {};
 
   ngOnInit(): void {
     this.ngControl?.control?.setValidators([this.validate.bind(this)]);
@@ -73,6 +73,8 @@ export class InputMaskDirective<T = any>
   writeValue(value: string): void {
     if (value) {
       this.renderer.setProperty(this.elementRef.nativeElement, 'value', value);
+    } else {
+      return;
     }
   }
 

--- a/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
+++ b/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
@@ -71,11 +71,11 @@ export class InputMaskDirective<T = any>
   }
 
   writeValue(value: string): void {
-    if (value) {
-      this.renderer.setProperty(this.elementRef.nativeElement, 'value', value);
-    } else {
-      return;
-    }
+    this.renderer.setProperty(
+      this.elementRef.nativeElement,
+      'value',
+      value ?? ''
+    );
   }
 
   registerOnChange(fn: (_: T | null) => void): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is no check in the writeValue method, so when the field is null there is an error as I mentioned in the issue.
Issue Number: [#6 ](https://github.com/ngneat/input-mask/issues/6)

## What is the new behavior?
Simply adding a null check to writeValue method solves the issue.

## Does this PR introduce a breaking change?

```
[ ] Yes
[ X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
