### PR TITLE
Fix/validation: correct validation error when filed is empty and valid

### DIFF
--- a/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
+++ b/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
@@ -41,7 +41,7 @@ export class InputMaskDirective<T = any>
   @HostListener('input', ['$event.target.value'])
   onInput = (_: any) => {};
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.ngControl?.control?.setValidators([this.validate.bind(this)]);
     this.ngControl?.control?.updateValueAndValidity();
   }
@@ -50,7 +50,7 @@ export class InputMaskDirective<T = any>
     this.inputMaskPlugin?.remove();
   }
 
-  ngAfterViewInit() {
+  ngAfterViewInit(): void {
     if (isPlatformServer(this.platformId)) {
       return;
     }
@@ -84,7 +84,9 @@ export class InputMaskDirective<T = any>
   registerOnTouched(fn: any): void {}
 
   validate(): { [key: string]: any } | null {
-    return this.inputMaskPlugin && this.inputMaskPlugin.isValid()
+    const isEmptyValue = !this.ngControl?.control?.value?.length;
+    return isEmptyValue ||
+      (this.inputMaskPlugin && this.inputMaskPlugin.isValid())
       ? null
       : { inputMask: false };
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The field now has an error like `{ inputMask: false }` also if it is empty and valid.

Issue Number: [#12](https://github.com/ngneat/input-mask/issues/12)

## What is the new behavior?
Now there is a check to avoid to set error if the field is valid and empty.

## Does this PR introduce a breaking change?

```
[ ] Yes
[ X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
