### PR TITLE
fix(input-mask.directive): disconnect mutation observer on destroy

### DIFF
--- a/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
+++ b/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
@@ -30,6 +30,7 @@ export class InputMaskDirective<T = any>
   inputMaskPlugin: Inputmask.Instance | undefined;
   nativeInputElement: HTMLInputElement | undefined;
   defaultInputMaskConfig = new InputMaskConfig();
+  private mutationObserver: MutationObserver | undefined;
 
   constructor(
     @Inject(PLATFORM_ID) private platformId: string,
@@ -50,7 +51,7 @@ export class InputMaskDirective<T = any>
       };
       if (this.defaultInputMaskConfig.isAsync) {
         // Create an observer instance linked to the callback function
-        const mutationObserver = new MutationObserver((mutationsList) => {
+        this.mutationObserver = new MutationObserver((mutationsList) => {
           for (const mutation of mutationsList) {
             if (mutation.type === 'childList') {
               const nativeInputElement = this.elementRef.nativeElement.querySelector(
@@ -58,7 +59,7 @@ export class InputMaskDirective<T = any>
               );
               if (nativeInputElement) {
                 this.nativeInputElement = nativeInputElement;
-                mutationObserver.disconnect();
+                this.mutationObserver?.disconnect();
                 this.initInputMask();
               }
             }
@@ -66,7 +67,7 @@ export class InputMaskDirective<T = any>
         });
 
         // Start observing the target node for configured mutations
-        mutationObserver.observe(this.elementRef.nativeElement, {
+        this.mutationObserver.observe(this.elementRef.nativeElement, {
           childList: true,
           subtree: true,
         });
@@ -88,6 +89,7 @@ export class InputMaskDirective<T = any>
 
   ngOnDestroy(): void {
     this.inputMaskPlugin?.remove();
+    this.mutationObserver?.disconnect();
   }
 
   initInputMask() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](./CONTRIBUTING.md#commit).
~~[ ] Tests for the changes have been added (for bug fixes / features)~~
~~[ ] Docs have been added / updated (for bug fixes / features)~~

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?

Disconnect `MutationObserver` on destory.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```