### PR TITLE
SSR issue with modules importing InputMaskModule

### DIFF
--- a/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
+++ b/projects/ngneat/input-mask/src/lib/input-mask.directive.ts
@@ -21,7 +21,6 @@ import {
   ValidationErrors,
   Validator,
 } from '@angular/forms';
-import _Inputmask from 'inputmask';
 import type Inputmask from 'inputmask';
 
 import { InputmaskOptions } from './types';
@@ -33,11 +32,6 @@ import { InputMaskConfig, INPUT_MASK_CONFIG } from './config';
 // a UMD format, to tell Webpack that there's a default export.
 // The `_Inputmask` is an object with 2 properties: `{ __esModule: true, default: Inputmask }`.
 // But we want to be backwards-compatible, so we try to read the `default` property first; otherwise, we fall back to `_Inputmask`.
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const InputmaskConstructor =
-  (_Inputmask as unknown as { default?: Inputmask.Static }).default ||
-  _Inputmask;
 
 @Directive({
   // eslint-disable-next-line @angular-eslint/directive-selector
@@ -152,7 +146,7 @@ export class InputMaskDirective<T = any>
     this.registerOnChange(this.onChange);
   }
 
-  private createInputMaskPlugin(): void {
+  private async createInputMaskPlugin() {
     const { nativeInputElement, inputMaskOptions } = this;
 
     if (
@@ -163,6 +157,17 @@ export class InputMaskDirective<T = any>
     ) {
       return;
     }
+
+    /* eslint-disable @typescript-eslint/naming-convention */
+    // @ts-ignore
+    const { default: _Inputmask } = await import(
+      'inputmask/dist/inputmask.es6'
+    );
+
+    const InputmaskConstructor =
+      (_Inputmask as unknown as { default?: Inputmask.Static }).default ||
+      _Inputmask;
+    /* eslint-enable @typescript-eslint/naming-convention */
 
     const { parser, formatter, ...options } = inputMaskOptions;
     this.inputMaskPlugin = this.ngZone.runOutsideAngular(() =>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](./CONTRIBUTING.md#commit).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

https://github.com/ngneat/input-mask/issues/97

Issue Number: 97

## What is the new behavior?

Importing `imputmask` library dynamically, so SSR is not broken.

## Does this PR introduce a breaking change?

Did not find issues in the prod app: still testing. 

```
[ ] Yes
[x] No
```

## Other information

This is just an idea how I solved the issue for the particular case, however I believe we can find a better alternative